### PR TITLE
Add production environment to mongoid.config

### DIFF
--- a/mongoid.config
+++ b/mongoid.config
@@ -3,7 +3,8 @@ development:
     default:
       database: facts_dev
       hosts:
-        - localhost:27017
+        <!-- - localhost:27017 -->
+        - 54.229.164.217:4567
 
 production:
   sessions:

--- a/mongoid.config
+++ b/mongoid.config
@@ -4,3 +4,10 @@ development:
       database: facts_dev
       hosts:
         - localhost:27017
+
+production:
+  sessions:
+    default:
+      database: facts_production
+      hosts:
+       - http://54.229.164.217:4567


### PR DESCRIPTION
∆ Set db name to 'facts_production'. Not sure if we have a specific
name that we should use instead?

∆ Set the host to the IP:port provided by Jialu.